### PR TITLE
Handle 204 (No Content) responses

### DIFF
--- a/tap_zoho_crm/__init__.py
+++ b/tap_zoho_crm/__init__.py
@@ -4,7 +4,6 @@ import sys
 import json
 import argparse
 import singer
-from singer import metadata, utils
 from tap_zoho_crm.client import ZohoClient
 from tap_zoho_crm.sync import sync
 

--- a/tap_zoho_crm/client.py
+++ b/tap_zoho_crm/client.py
@@ -122,7 +122,7 @@ class ZohoClient:
             self.request_refresh_token()
         else:
             response.raise_for_status()
-            return response.json()
+            return None if response.status_code == 204 else response.json()
 
         raise WaitAndRetry()
 

--- a/tap_zoho_crm/client.py
+++ b/tap_zoho_crm/client.py
@@ -1,4 +1,3 @@
-import os
 import requests
 import json
 from requests.exceptions import ConnectionError, Timeout, HTTPError

--- a/tap_zoho_crm/sync.py
+++ b/tap_zoho_crm/sync.py
@@ -1,8 +1,4 @@
 # pylint: disable=too-many-lines
-from datetime import date, datetime, timedelta
-import time
-from urllib.parse import urlparse
-from dateutil.parser import parse
 from tap_zoho_crm.client import ZohoFeatureNotEnabled
 from tap_zoho_crm.modules import (
     NON_PAGINATE_MODULES,


### PR DESCRIPTION
I've explicitly added a case for 204 responses, so that we'll receive an error in case any other 2xx response should, for some reason, return an empty response body. This feels like the better way to go about it, since the Zoho CRM API documentation is rather lacking.

As an aside, it actually seems like the `Approvals` module might have been removed.
It's not listed [in the modules API documentation](https://www.zoho.com/crm/developer/docs/api/v2/get-records.html), and when I contacted their support about it, I was simply told there wasn't any documentation related to approvals.

From what I could gather after interrogating @JingLin0, it doesn't seem like we're actually using the `approvals` stream anyhow, so maybe it should just be removed?